### PR TITLE
RecyclerView 에서 사용시 뷰가 튕기는 현상 수정해보았습니다.

### DIFF
--- a/readmore-textview/src/main/java/kr/co/prnd/readmore/ReadMoreTextView.kt
+++ b/readmore-textview/src/main/java/kr/co/prnd/readmore/ReadMoreTextView.kt
@@ -24,7 +24,10 @@ class ReadMoreTextView @JvmOverloads constructor(
         private set(value) {
             field = value
             text = when (value) {
-                State.EXPANDED -> originalText
+                State.EXPANDED -> {
+                    maxLines = Int.MAX_VALUE
+                    originalText
+                }
                 State.COLLAPSED -> collapseText
             }
             changeListener?.onStateChange(value)
@@ -100,7 +103,8 @@ class ReadMoreTextView @JvmOverloads constructor(
             return
         }
         originalText = text
-
+        maxLines = readMoreMaxLine
+        
         val adjustCutCount = getAdjustCutCount(readMoreMaxLine, readMoreText)
         val maxTextIndex = layout.getLineVisibleEnd(readMoreMaxLine - 1)
         val originalSubText = originalText.substring(0, maxTextIndex - 1 - adjustCutCount)


### PR DESCRIPTION
이슈 및 수정 사항입니다.

-  `RecyclerView`위로 스크롤시 길어진 `TextView`를 readMore로 줄이는 과정에서 발생하는것으로 파악하였음
-  `setupReadMore`시에 `maxLines`을 `readMoreMaxLine`로 설정
- `state`가 `EXPANDED`로 변경될시 `maxLines`을 기본값으로 초기화